### PR TITLE
Use musl instead of gnu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             name: spotify-reshuffle-linux-intel
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             name: spotify-reshuffle-linux-arm64
           - os: macos-latest
             target: x86_64-apple-darwin


### PR DESCRIPTION
Gnu binary is dynamically linked and requires `/lib/ld-linux-aarch64.so.1`.

Compiling a statically linked binary is better than mounting system libraries, not necessarily available in docker image environment for instance.

This PR switch linux builds to musl targets